### PR TITLE
Center pile mat in middle area

### DIFF
--- a/src/components/Gameboard.tsx
+++ b/src/components/Gameboard.tsx
@@ -456,7 +456,7 @@ export const Gameboard: React.FC<GameboardProps> = ({ theme, toggleTheme }) => {
             {/* Pile Mat */}
             <div
               className={cn(
-                "bg-black/40 border border-white/5 rounded-3xl px-4 sm:px-6 md:px-8 py-5 sm:py-7 md:py-8 shadow-2xl backdrop-blur-xl flex items-center gap-6 sm:gap-10 md:gap-14 relative z-10 w-full max-w-4xl",
+                "bg-black/40 border border-white/5 rounded-3xl px-4 sm:px-6 md:px-8 py-5 sm:py-7 md:py-8 shadow-2xl backdrop-blur-xl inline-flex items-center justify-center gap-6 sm:gap-10 md:gap-14 relative z-10 mx-auto",
                 isCompact && "px-3 sm:px-4 py-4 sm:py-5 gap-4 sm:gap-6 md:gap-8"
               )}
             >


### PR DESCRIPTION
### TL;DR

Updated the Pile Mat container styling to improve layout and centering.

### What changed?

Modified the CSS classes for the Pile Mat container in the Gameboard component:
- Changed `flex` to `inline-flex` for better container sizing
- Added `justify-center` to center items horizontally
- Replaced `w-full max-w-4xl` with `mx-auto` to center the container itself

### How to test?

1. Open the application and navigate to the Gameboard
2. Verify that the Pile Mat is properly centered on the screen
3. Check that cards within the Pile Mat are evenly spaced and centered
4. Test on different screen sizes to ensure responsive behavior works correctly

### Why make this change?

This styling update improves the visual presentation of the Pile Mat by ensuring it's properly centered and sized. The change from `flex` to `inline-flex` allows the container to size based on its content rather than expanding to full width, while `justify-center` ensures the cards are evenly distributed within the container.